### PR TITLE
enable 'maintainScroll' usage with FlowRouter

### DIFF
--- a/client/router-autoscroll.js
+++ b/client/router-autoscroll.js
@@ -54,7 +54,9 @@ var scheduleScroll = function () {
 };
 
 var flowScroll = function (newRoute) {
-  if(newRoute.context.pathname.indexOf("#") == -1)
+  if(newRoute.queryParams.maintainScroll)
+    return; // flow router does not support #
+  else if(newRoute.context.pathname.indexOf("#") == -1)
     scrollTo(0);
   else
     scheduleScroll();


### PR DESCRIPTION
FlowRouter unfortunately does not support adding has tags at any given time, so lets also include the use of query strings.
