### PR TITLE
Add marginTop configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ To change this use:
 RouterAutoscroll.animationDuration = 100;
 ```
 
+For some cases (top fixed elements), margins are needed.
+To set this use:
+
+``` javascript
+RouterAutoscroll.marginTop = 50;
+```
+
 To navigate to a route and explicitly maintain scroll position, pass
 `maintainScroll=1` in the hash:
 

--- a/client/router-autoscroll.js
+++ b/client/router-autoscroll.js
@@ -1,5 +1,6 @@
 RouterAutoscroll = {
   animationDuration: 200,
+  marginTop: 0
 };
 
 var backToPosition;
@@ -8,7 +9,7 @@ var scrollPositions = new ReactiveDict("okgrow-router-autoscroll");
 
 function saveScrollPosition () {
   scrollPositions.set(window.location.href, $(window).scrollTop());
-};
+}
 
 //TODO use history state so we don't litter
 window.onpopstate = function () {
@@ -58,7 +59,7 @@ var flowScroll = function (newRoute) {
     scrollTo(0);
   else
     scheduleScroll();
-}
+};
 
 function ironWhenReady (callFn) {
   return function () {
@@ -71,7 +72,7 @@ function ironWhenReady (callFn) {
 
 function scrollTo (position) {
   $('body,html').animate({
-    scrollTop: position
+    scrollTop: position - RouterAutoscroll.marginTop
   }, RouterAutoscroll.animationDuration);
 }
 
@@ -110,6 +111,6 @@ HotCodePush.end.then(function () {
   if (backToPosition) {
     scheduleScroll();
   }
-})
+});
 
 RouterAutoscroll.scrollPositions = scrollPositions;


### PR DESCRIPTION
In some cases, projects have top fixed elements like navbars.
It was an issue because **fixed elements were hidding parts of sections**.

This pull-request just involve a **new parameter** called `marginTop`.
We configure it juste like this:

``` javascript
RouterAutoscroll.marginTop = 50;
```

Autoscroll will  `animate()` to top of `position` minus `RouterAutoscroll.marginTop`.
Nothing more.
