### PR TITLE
don't scroll when maintainScroll=1

### DIFF
--- a/client/router-autoscroll.js
+++ b/client/router-autoscroll.js
@@ -94,6 +94,8 @@ var scrollTop = function () {
 }
 
 var scrollTo = function (position) {
+  if (position === undefined) return;
+
   if (_jQuery) {
     _jQuery('body,html').animate({
       scrollTop: position - RouterAutoscroll.marginTop


### PR DESCRIPTION
We're using autoscroll in our App, but in some places we want to disable it. This is a quick fix for the maintainScroll=1 feature. I didn't put much thought to it, so there's likely a better way.
